### PR TITLE
feat: Add Windows installation script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ cp conf.yaml.example conf.yaml
 brew install marp-cli
 ```
 
+### Windows Installation
+
+Windows users can simplify the setup process by using the provided batch script:
+
+1.  After cloning the repository, navigate to its root directory in your command prompt.
+2.  Run the `install_windows.bat` script:
+    ```batch
+    install_windows.bat
+    ```
+3.  This script will:
+    *   Check for `uv` and `pnpm` and guide you if they are missing.
+    *   Install Python dependencies using `uv sync`.
+    *   Install Node.js dependencies for the web UI (in the `web` directory) using `pnpm install`.
+    *   Copy necessary configuration files (`.env.example` to `.env`, `conf.yaml.example` to `conf.yaml`).
+    *   Provide instructions for installing `marp-cli` (required for PPT generation).
+4.  After the script completes, ensure you configure your `.env` and `conf.yaml` files with your API keys and preferred settings as mentioned in the general instructions and the [Configuration Guide](docs/configuration_guide.md).
+
+For other operating systems, or for manual installation on Windows, please follow the steps below.
+
 Optionally, install web UI dependencies via [pnpm](https://pnpm.io/installation):
 
 ```bash

--- a/install_windows.bat
+++ b/install_windows.bat
@@ -1,0 +1,83 @@
+@echo off
+SETLOCAL ENABLEEXTENSIONS
+
+ECHO Checking for uv...
+uv --version >nul 2>&1
+IF ERRORLEVEL 1 (
+    ECHO uv is not installed or not in PATH. Please install it from https://docs.astral.sh/uv/getting-started/installation/ and re-run this script.
+    GOTO EOF
+)
+
+ECHO Installing Python dependencies using uv...
+uv sync
+IF ERRORLEVEL 1 (
+    ECHO uv sync failed. Please check for errors.
+    GOTO EOF
+)
+
+ECHO Copying .env.example to .env...
+copy .env.example .env
+ECHO Copying conf.yaml.example to conf.yaml...
+copy conf.yaml.example conf.yaml
+
+ECHO Checking for pnpm...
+pnpm --version >nul 2>&1
+IF ERRORLEVEL 1 (
+    ECHO pnpm is not installed or not in PATH. Please install it from https://pnpm.io/installation/ and re-run this script.
+    GOTO EOF
+)
+
+ECHO Navigating to web directory...
+cd web
+IF ERRORLEVEL 1 (
+    ECHO Failed to navigate to web directory. Ensure it exists in the current path.
+    GOTO EOF
+)
+
+ECHO Installing web UI dependencies using pnpm...
+pnpm install
+IF ERRORLEVEL 1 (
+    ECHO pnpm install failed. Please check for errors.
+    cd ..
+    GOTO EOF
+)
+
+ECHO Navigating back to root directory...
+cd ..
+IF ERRORLEVEL 1 (
+    ECHO Failed to navigate back to root directory.
+    GOTO EOF
+)
+
+ECHO.
+ECHO --- Marp CLI Installation ---
+ECHO This project uses marp-cli for PPT generation.
+
+npm --version >nul 2>&1
+IF ERRORLEVEL 1 (
+    ECHO npm (Node Package Manager) is not detected. marp-cli is typically installed using npm.
+    ECHO Please install Node.js (which includes npm) from https://nodejs.org/.
+    ECHO After installing Node.js, you can install marp-cli globally by running this command in your terminal:
+    ECHO   npm install -g @marp-team/marp-cli
+) ELSE (
+    ECHO npm detected. You can install marp-cli globally by running the following command in your terminal:
+    ECHO   npm install -g @marp-team/marp-cli
+)
+ECHO Alternatively, refer to marp-cli installation options at https://github.com/marp-team/marp-cli#install
+ECHO.
+
+ECHO --- Configuration Required ---
+ECHO Installation steps complete!
+ECHO IMPORTANT: Please configure your API keys and other settings in the following files:
+ECHO   - .env
+ECHO   - conf.yaml
+ECHO Refer to the README.md and docs/configuration_guide.md for details.
+ECHO.
+ECHO Once configured, you can start the application using:
+ECHO   bootstrap.bat
+ECHO Or for development mode:
+ECHO   bootstrap.bat -d
+ECHO.
+
+:EOF
+ENDLOCAL


### PR DESCRIPTION
This commit introduces a new `install_windows.bat` script to simplify the setup process for Windows users.

The script automates:
- Checking for `uv` and `pnpm` prerequisites.
- Installation of Python dependencies using `uv sync`.
- Installation of Node.js dependencies for the web UI via `pnpm install`.
- Copying of example configuration files (`.env.example`, `conf.yaml.example`).
- Guidance for installing `marp-cli`.

The README.md file has been updated to include a new "Windows Installation" section, instructing you to utilize the new batch script. Existing manual installation instructions remain for other operating systems and for those of you who prefer a manual setup.